### PR TITLE
Add editing environment doc and Makefile. Update README with relative links and a link pointing to editing.adoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+venv/
+
+dist/
+
 *.html
 
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+watch:
+	mkdir -p dist/
+	cp *.ttl dist/
+	cp -r images dist/
+	mkdir -p dist/backbone
+	cp backbone/model.ttl dist/backbone/model.ttl
+	mkdir -p dist/placenames
+	cp placenames/*.ttl dist/placenames/
+	cp placenames/*.png dist/placenames/
+	make build
+	watchmedo shell-command \
+		--patterns="*.adoc;*.css" \
+		--ignore-directories \
+		--recursive \
+		--command='make build' \
+		.
+
+build:
+	asciidoctor README.adoc -o dist/index.html
+	asciidoctor supermodel.adoc -o dist/supermodel.html
+	asciidoctor placenames/model.adoc -o dist/placenames/index.html
+
+http:
+	httpwatcher --root dist \
+		--host 127.0.0.1 \
+		--port 8000 \
+		--no-browser

--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,8 @@
 
 This document is both the front page of the Queensland Land Information Supermodel's repository and a _Guidance document_ and introduces all the other elements of this Supermodel.
 
+To contribute to this document, see link:editing.adoc[] on how to set up the editing environment.
+
 == Metadata
 
 [width=75%, frame=none, grid=none, cols="1,5"]
@@ -22,14 +24,14 @@ This document is both the front page of the Queensland Land Information Supermod
 
 == Components
 
-* https://nicholascar.com/qsi-supermodel/supermodel.html[Specification]
-* https://nicholascar.com/qsi-supermodel/backbone/model.ttl[Backbone Model]
+* link:supermodel.html[Specification]
+* link:backbone/model.ttl[Backbone Model]
 ** machine-readable version
 * https://w3id.org/profile/anz-address[Address Model]
 ** external to this Supermodel
 * https://w3id.org/profile/qsi-placenames[Place Names Model]
 ** defined within this Supermodel
-* https://nicholascar.com/qsi-supermodel/supermodel.html#_qsi_cadastral_model[Cadastre Model]
+* link:supermodel.html#_qsi_cadastral_model[Cadastre Model]
 ** defined within this Supermodel
 
 // == Introduction

--- a/editing.adoc
+++ b/editing.adoc
@@ -1,0 +1,73 @@
+= Setting up the editing environment
+
+As an editor of this document, first thing to do is to install the required dependencies in order to set up the editing environment.
+
+== Required dependencies
+
+=== asciidoctor
+
+For details on the different ways to install asciidoctor, please see https://asciidoctor.org/#installation. Otherwise, continue reading the next few sections on how to install asciidoctor on Windows and macOS.
+
+==== Windows
+
+The recommended way to install asciidoctor on Windows is by installing Ruby first via the https://chocolatey.org/[chocolatey package manager]. Once chocolatey is installed, open PowerShell and type:
+
+----
+choco install ruby
+----
+
+Now that Ruby is installed, install asciidoctor with the gem package manager.
+
+----
+gem install asciidoctor
+----
+
+You should now be able to run `asciidoctor` in PowerShell.
+
+==== macOS and Linux
+
+The recommended way to install asciidoctor on macOS or a Linux distribution is via the https://brew.sh/[Homebrew (brew) package manager]. Once brew is installed, open a terminal and type:
+
+----
+brew install asciidoctor
+----
+
+You should now be able to run `asciidoctor` in the terminal.
+
+== Optional dependencies
+
+* Python version 3+
+
+=== Working with optional dependencies
+
+With Python installed, as you are editing, you can set it up to auto-compile asciidoc documents on change and see it rendered live in a browser.
+
+Create a python virtual environment and install watchdog and httpwatcher.
+
+----
+python -m venv venv
+source venv/bin/activate
+pip install watchdog git+https://github.com/thanethomson/httpwatcher.git@dev
+----
+
+=== The editing environment
+
+Ensure a python virtual environment is set up and activated with the dependencies installed.
+
+Use this repository's `Makefile` to start the file watcher in the terminal.
+
+----
+make watch
+----
+
+This will transpile all *.adoc files in this repository to static web files in `dist/`.
+
+In a separate terminal, start the hot-reloading http web server.
+
+----
+make http
+----
+
+This will watch the `dist/` directory and hot-reload the web page using websockets.
+
+Try and edit a file ending in `.adoc` and see the web page update live at http://127.0.0.1:8000.


### PR DESCRIPTION
This PR adds an `editing.adoc` file to describe how to set up asciidoctor, etc for editors of this document.

Hardcoded URLs have been changed to relative URLs.

A `Makefile` with watch, build and http commands have been added for a nice editing experience.